### PR TITLE
Regression fix, errorhandling, dockerfile-parsing accuracy improvement

### DIFF
--- a/internal/fetcher/github.go
+++ b/internal/fetcher/github.go
@@ -626,6 +626,10 @@ func ExtractFiles(data map[string]interface{}) map[string][]models.FileEntry {
 					continue
 				}
 				// For Dockerfiles, we want the content to analyze them later
+				if !parser.LooksLikeDockerfile(content){
+					slog.Debug("Skipper Dockerfile-kandidat med ugyldig innhold", "path", name)
+					continue
+				}
 				if content != "" {
 					files[fileType] = append(files[fileType], map[string]string{
 						"path":    name,
@@ -839,6 +843,9 @@ func (r *RepoFetcher) FetchDockerfilesFromTree(ctx context.Context, owner, repo 
 			continue
 		}
 		content := r.fetchFileContent(ctx, owner, repo, entry.Path)
+		if !parser.LooksLikeDockerfile(content){
+			continue
+		}
 		if content != "" {
 			results = append(results, models.FileEntry{
 				Path:    entry.Path,

--- a/internal/fetcher/github.go
+++ b/internal/fetcher/github.go
@@ -828,6 +828,7 @@ func (r *RepoFetcher) FetchDockerfilesFromTree(ctx context.Context, owner, repo 
 		// Extract just the filename from the path
 		pathParts := strings.Split(entry.Path, "/")
 		filename := pathParts[len(pathParts)-1]
+		lowername := strings.ToLower(filename)
 
 		// Skip root-level files (they were already fetched via GraphQL)
 		if len(pathParts) == 1 {
@@ -839,7 +840,11 @@ func (r *RepoFetcher) FetchDockerfilesFromTree(ctx context.Context, owner, repo 
 		if entry.Size == 0 {
 			continue
 		}
-		if !isDockerfile(filename) {
+		// Skip root-level files (they were already fetched via GraphQL)
+		if len(pathParts) == 1 {
+			continue
+		}
+		if !isDockerfile(lowername) {
 			continue
 		}
 		content := r.fetchFileContent(ctx, owner, repo, entry.Path)

--- a/internal/parser/dockerfileparser.go
+++ b/internal/parser/dockerfileparser.go
@@ -3,6 +3,7 @@ package parser
 import (
 	"regexp"
 	"strings"
+	"unicode/utf8"
 )
 
 type DockerfileFeatures struct {
@@ -50,6 +51,12 @@ type fromInstruction struct {
 	unresolved bool
 	parseable  bool
 }
+
+// LooksLikeDockerfile checks whether content is valid UTF-8 text
+// Could add more rules
+func LooksLikeDockerfile(content string) bool {
+	return utf8.ValidString(content)
+	}
 
 func ParseDockerfile(content string) (DockerfileFeatures, []DockerStageMeta) {
 	var features DockerfileFeatures

--- a/internal/parser/dockerfileparser.go
+++ b/internal/parser/dockerfileparser.go
@@ -81,6 +81,7 @@ func ParseDockerfile(content string) (DockerfileFeatures, []DockerStageMeta) {
 				continue
 			}
 			resolvedValue, _ := resolveArgReferences(defaultValue, globalArgs)
+			resolvedValue = trimMatchingQuotes(resolvedValue)
 			globalArgs[name] = resolvedValue
 		case "from":
 			seenFrom = true
@@ -241,6 +242,7 @@ func parseFromInstruction(value string, knownAliases map[string]struct{}, global
 	imageRef := fields[i]
 	i++
 	resolvedRef, unresolved := resolveArgReferences(imageRef, globalArgs)
+	resolvedRef = trimMatchingQuotes(resolvedRef)
 
 	var alias string
 	if i+1 < len(fields) && strings.EqualFold(fields[i], "as") {
@@ -331,4 +333,18 @@ func splitDockerImageReference(ref string) (string, string) {
 	}
 
 	return ref, "latest"
+}
+
+func trimMatchingQuotes(value string) string {
+	if len(value) < 2 {
+		return value
+	}
+
+	first := value[0]
+	last := value[len(value)-1]
+	if (first == '"' || first == '\'') && first == last {
+		return value[1 : len(value)-1]
+	}
+
+	return value
 }

--- a/internal/parser/dockerfileparser.go
+++ b/internal/parser/dockerfileparser.go
@@ -56,7 +56,7 @@ type fromInstruction struct {
 // Could add more rules
 func LooksLikeDockerfile(content string) bool {
 	return utf8.ValidString(content)
-	}
+}
 
 func ParseDockerfile(content string) (DockerfileFeatures, []DockerStageMeta) {
 	var features DockerfileFeatures
@@ -312,7 +312,16 @@ func splitDockerImageReference(ref string) (string, string) {
 	}
 
 	if at := strings.Index(ref, "@"); at >= 0 {
-		return ref[:at], ""
+		imageRef := ref[:at]
+		digest := ref[at+1:]
+
+		lastSlash := strings.LastIndex(imageRef, "/")
+		lastColon := strings.LastIndex(imageRef, ":")
+		if lastColon > lastSlash {
+			return imageRef[:lastColon], imageRef[lastColon+1:] + "@" + digest
+		}
+
+		return imageRef, digest
 	}
 
 	lastSlash := strings.LastIndex(ref, "/")

--- a/internal/parser/dockerfileparser_test.go
+++ b/internal/parser/dockerfileparser_test.go
@@ -359,6 +359,47 @@ FROM ${NODE_BUILD_IMG} AS prepare`,
 			},
 		),
 
+		Entry("Quoted global ARG default resolves FROM image reference",
+			`ARG NODE_BUILD_IMG="node:20-alpine"
+FROM ${NODE_BUILD_IMG} AS prepare`,
+			parser.DockerfileFeatures{
+				BaseImage:     "node",
+				BaseTag:       "20-alpine",
+				UsesLatestTag: false,
+			},
+		),
+
+		Entry("Quoted chained global ARG defaults resolve before FROM parsing",
+			`ARG NODE_VERSION="20-alpine"
+ARG NODE_BUILD_IMG="node:${NODE_VERSION}"
+FROM ${NODE_BUILD_IMG} AS prepare`,
+			parser.DockerfileFeatures{
+				BaseImage:     "node",
+				BaseTag:       "20-alpine",
+				UsesLatestTag: false,
+			},
+		),
+
+		Entry("Quoted empty single-quote ARG prefix resolves before FROM parsing",
+			`ARG REPO_LOCATION=''
+FROM ${REPO_LOCATION}node:18.20.8-alpine3.21`,
+			parser.DockerfileFeatures{
+				BaseImage:     "node",
+				BaseTag:       "18.20.8-alpine3.21",
+				UsesLatestTag: false,
+			},
+		),
+
+		Entry("Quoted empty double-quote ARG prefix resolves before FROM parsing",
+			`ARG BASE_IMAGE_PREFIX=""
+FROM ${BASE_IMAGE_PREFIX}maven AS builder`,
+			parser.DockerfileFeatures{
+				BaseImage:     "maven",
+				BaseTag:       "latest",
+				UsesLatestTag: true,
+			},
+		),
+
 		Entry("COPY with flags still detects sensitive paths",
 			`FROM alpine AS base
 COPY --from=builder .ssh /root/.ssh`,
@@ -432,6 +473,30 @@ FROM base AS final`,
 FROM --platform=${BUILDPLATFORM} ${NODE_BUILD_IMG} AS prepare`,
 			[]parser.DockerStageMeta{
 				{StageIndex: 0, BaseImage: "node", BaseTag: "20-alpine"},
+			},
+		),
+
+		Entry("Quoted global ARG default resolves stage metadata from FROM",
+			`ARG MAVEN_BUILD_IMG='maven:3.9-eclipse-temurin-21'
+FROM ${MAVEN_BUILD_IMG} AS build`,
+			[]parser.DockerStageMeta{
+				{StageIndex: 0, BaseImage: "maven", BaseTag: "3.9-eclipse-temurin-21"},
+			},
+		),
+
+		Entry("Quoted empty single-quote ARG prefix resolves stage metadata from FROM",
+			`ARG REPO_LOCATION=''
+FROM ${REPO_LOCATION}node:18.20.8-alpine3.21`,
+			[]parser.DockerStageMeta{
+				{StageIndex: 0, BaseImage: "node", BaseTag: "18.20.8-alpine3.21"},
+			},
+		),
+
+		Entry("Quoted empty double-quote ARG prefix resolves stage metadata from FROM",
+			`ARG BASE_IMAGE_PREFIX=""
+FROM ${BASE_IMAGE_PREFIX}maven AS builder`,
+			[]parser.DockerStageMeta{
+				{StageIndex: 0, BaseImage: "maven", BaseTag: "latest"},
 			},
 		),
 

--- a/internal/parser/dockerfileparser_test.go
+++ b/internal/parser/dockerfileparser_test.go
@@ -93,11 +93,20 @@ COPY --from=builder /app /app`,
 			},
 		),
 
-		Entry("Digest reference does not imply latest",
+		Entry("Digest reference is preserved in base tag",
 			`FROM alpine@sha256:deadbeef`,
 			parser.DockerfileFeatures{
 				BaseImage:     "alpine",
-				BaseTag:       "",
+				BaseTag:       "sha256:deadbeef",
+				UsesLatestTag: false,
+			},
+		),
+
+		Entry("Tag and digest are both preserved in base tag",
+			`FROM europe-north1-docker.pkg.dev/cgr-nav/pull-through/nav.no/node:24-slim@sha256:5aac35a0b0f5c43f19d9bfaa0663a0e177903b44f7d8b80f4fd5f928bedfe3ca`,
+			parser.DockerfileFeatures{
+				BaseImage:     "europe-north1-docker.pkg.dev/cgr-nav/pull-through/nav.no/node",
+				BaseTag:       "24-slim@sha256:5aac35a0b0f5c43f19d9bfaa0663a0e177903b44f7d8b80f4fd5f928bedfe3ca",
 				UsesLatestTag: false,
 			},
 		),
@@ -396,10 +405,17 @@ FROM alpine:3.20`,
 			},
 		),
 
-		Entry("Digest references produce empty base tag",
+		Entry("Digest references are preserved in stage base tag",
 			`FROM alpine@sha256:deadbeef`,
 			[]parser.DockerStageMeta{
-				{StageIndex: 0, BaseImage: "alpine", BaseTag: ""},
+				{StageIndex: 0, BaseImage: "alpine", BaseTag: "sha256:deadbeef"},
+			},
+		),
+
+		Entry("Tag and digest are both preserved in stage base tag",
+			`FROM europe-north1-docker.pkg.dev/cgr-nav/pull-through/nav.no/node:24-slim@sha256:5aac35a0b0f5c43f19d9bfaa0663a0e177903b44f7d8b80f4fd5f928bedfe3ca`,
+			[]parser.DockerStageMeta{
+				{StageIndex: 0, BaseImage: "europe-north1-docker.pkg.dev/cgr-nav/pull-through/nav.no/node", BaseTag: "24-slim@sha256:5aac35a0b0f5c43f19d9bfaa0663a0e177903b44f7d8b80f4fd5f928bedfe3ca"},
 			},
 		),
 


### PR DESCRIPTION
Regression fix where missing strings.toLower(filename) resulted in skipping dockerfiles. 

Added `parser.LooksLikeDockerfile(...)` to reject Dockerfile candidates that are not valid UTF-8 text (incredible that this has not been an issue thus far). Applied the guard in both dockerfile ingestion paths in github.go. 

Correctness fixes in parsing of Dockerfiles to base_image/base_tag.